### PR TITLE
Prevent S3 upload of temporary import files

### DIFF
--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -311,6 +311,28 @@ def file_upload_to_s3(doc, method):
     ignore_s3_upload_for_doctype = frappe.local.conf.get(
         "ignore_s3_upload_for_doctype"
     ) or ["Data Import", "Bank Statement Import", "Chart of Accounts Importer"]
+
+    # Loose-file safety net. Frappe's importer wizard (Data Import, the
+    # per-doctype "Import" action used by Bank Transaction, etc.) creates the
+    # File row BEFORE the parent Data Import doc, so the doctype check above
+    # sees attached_to_doctype="" and happily ships the CSV to S3. The
+    # importer then re-opens the file_url with open() and crashes with
+    # FileNotFoundError on the rewritten /api/method/...generate_file?... URL.
+    # Files with no parent doctype AND an importer-style extension are
+    # virtually always working files for an import-in-progress — keep them
+    # local. Operators can override via the
+    # ``ignore_s3_upload_for_extensions`` site config key (set to [] to
+    # disable this fallback entirely).
+    ignore_s3_upload_for_extensions = frappe.local.conf.get(
+        "ignore_s3_upload_for_extensions"
+    )
+    if ignore_s3_upload_for_extensions is None:
+        ignore_s3_upload_for_extensions = [".csv", ".xls", ".xlsx", ".json"]
+    if not doc.attached_to_doctype:
+        file_ext = os.path.splitext(doc.file_name or "")[1].lower()
+        if file_ext in ignore_s3_upload_for_extensions:
+            return
+
     if parent_doctype not in ignore_s3_upload_for_doctype:
         if not doc.is_private:
             file_path = site_path + "/public" + path


### PR DESCRIPTION
## Summary
Add a safety net to prevent temporary import files from being uploaded to S3, which was causing FileNotFoundError crashes when Frappe's importer wizard tried to re-open files with rewritten S3 URLs.

## Key Changes
- Added extension-based filtering for files without a parent doctype to catch temporary import files before S3 upload
- Default ignored extensions: `.csv`, `.xls`, `.xlsx`, `.json` (common import file formats)
- Made the behavior configurable via the `ignore_s3_upload_for_extensions` site config key
- Operators can disable this fallback by setting the config to an empty list

## Implementation Details
The issue occurred because Frappe's importer wizard creates File records before the parent Data Import document exists, causing `attached_to_doctype` to be empty. The existing doctype-based check couldn't catch these orphaned files. This change adds a secondary check: files with no parent doctype and importer-style extensions are kept local, preventing the subsequent FileNotFoundError when the importer tries to open the file using the rewritten S3 URL.

https://claude.ai/code/session_01FEVzE2jqJhFCioLcoFk3fu